### PR TITLE
Fix URL encoding issue when value is null or empty

### DIFF
--- a/src/main/java/com/twikey/TwikeyClient.java
+++ b/src/main/java/com/twikey/TwikeyClient.java
@@ -122,6 +122,11 @@ public class TwikeyClient {
         StringBuilder result = new StringBuilder();
         boolean first = true;
         for (Map.Entry<String, String> entry : params.entrySet()) {
+            String value = entry.getValue();
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+
             if (first)
                 first = false;
             else

--- a/src/test/java/com/twikey/TwikeyClientTest.java
+++ b/src/test/java/com/twikey/TwikeyClientTest.java
@@ -2,8 +2,10 @@ package com.twikey;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 public class TwikeyClientTest {
 
@@ -26,6 +28,26 @@ public class TwikeyClientTest {
         String[] ibanAndBic = TwikeyClient.decryptAccountInformation(websiteKey, doc, encryptedAccountInOutcome);
         assertEquals("BE08001166979213",ibanAndBic[0]);
         assertEquals("GEBABEBB",ibanAndBic[1]);
+    }
+
+    @Test
+    public void test_getPostDataString_skipEmptyValues() {
+        // map with null keys
+        Map<String, String> params = new HashMap<>();
+        params.put("testing", null);
+        params.put("has", "value");
+
+        String data = TwikeyClient.getPostDataString(params);
+        assertEquals("has=value", data);
+    }
+
+    @Test
+    public void test_getPostDataString_urlEncoding() {
+        Map<String, String> params = new HashMap<>();
+        params.put("safe", "hello world");
+
+        String data = TwikeyClient.getPostDataString(params);
+        assertEquals("safe=hello+world", data);
     }
 
 }


### PR DESCRIPTION
## Issue

A `NullPointerException` is thrown when a null value is passed along in the form parameters list. 

## Changes

* Added exclusion to ignore `null` or `empty` values from form parameters
* Added tests for form values with null values
* Added tests for URL encoded values