### PR TITLE
Add custom attribute support to CreateInvoiceRequest

### DIFF
--- a/src/main/java/com/twikey/modal/InvoiceRequests.java
+++ b/src/main/java/com/twikey/modal/InvoiceRequests.java
@@ -53,6 +53,7 @@ public interface InvoiceRequests {
         private String ct;
         private Boolean manual;
         private List<LineItem> lines;
+        private Map<String, String> extra;
 
         public CreateInvoiceRequest(String number, Double amount, String date, String duedate, DocumentRequests.Customer customer) {
             this.number = number;
@@ -138,6 +139,11 @@ public interface InvoiceRequests {
             return this;
         }
 
+        public CreateInvoiceRequest setExtra(Map<String, String> extra) {
+            this.extra = extra;
+            return this;
+        }
+
         /**
          * Converts this request to a Map suitable for API submission.
          */
@@ -179,6 +185,9 @@ public interface InvoiceRequests {
                 List<JSONObject> lineMaps = new ArrayList<>();
                 for (LineItem line : lines) lineMaps.add(line.toMap());
                 map.put("lines", lineMaps.toString());
+            }
+            if (extra != null) {
+                extra.forEach(map::put);
             }
             return map;
         }

--- a/src/test/java/com/twikey/InvoiceGatewayTest.java
+++ b/src/test/java/com/twikey/InvoiceGatewayTest.java
@@ -83,7 +83,7 @@ public class InvoiceGatewayTest {
         String number = "Inv-CustomAttr-" + System.currentTimeMillis();
         InvoiceRequests.CreateInvoiceRequest request = new InvoiceRequests.CreateInvoiceRequest(
                 number, 50.0, LocalDate.now().toString(), LocalDate.now().plusMonths(1).toString(), customer)
-                .setExtra(Map.of("vehicle", "BMW 3-Series"));
+                .setExtra(Map.of("myCustomAttribute", "BMW 3-Series"));
         InvoiceResponse.Invoice response = api.invoice().create(request);
         assertNotNull("Invoice Id", response.getId());
         System.out.printf("Created invoice %s with custom attribute vehicle%n", response.getId());

--- a/src/test/java/com/twikey/InvoiceGatewayTest.java
+++ b/src/test/java/com/twikey/InvoiceGatewayTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
@@ -75,6 +76,18 @@ public class InvoiceGatewayTest {
         api.invoice().action(actionRequest);
     }
 
+
+    @Test
+    public void testCreateInvoiceWithCustomAttribute() throws IOException, TwikeyClient.UserException {
+        Assume.assumeTrue("APIKey is set", apiKey != null);
+        String number = "Inv-CustomAttr-" + System.currentTimeMillis();
+        InvoiceRequests.CreateInvoiceRequest request = new InvoiceRequests.CreateInvoiceRequest(
+                number, 50.0, LocalDate.now().toString(), LocalDate.now().plusMonths(1).toString(), customer)
+                .setExtra(Map.of("vehicle", "BMW 3-Series"));
+        InvoiceResponse.Invoice response = api.invoice().create(request);
+        assertNotNull("Invoice Id", response.getId());
+        System.out.printf("Created invoice %s with custom attribute vehicle%n", response.getId());
+    }
 
     @Test(expected = TwikeyClient.UserException.class)
     public void testUBLUpload() throws IOException, TwikeyClient.UserException {

--- a/src/test/java/com/twikey/InvoiceGatewayTest.java
+++ b/src/test/java/com/twikey/InvoiceGatewayTest.java
@@ -86,7 +86,7 @@ public class InvoiceGatewayTest {
                 .setExtra(Map.of("myCustomAttribute", "BMW 3-Series"));
         InvoiceResponse.Invoice response = api.invoice().create(request);
         assertNotNull("Invoice Id", response.getId());
-        System.out.printf("Created invoice %s with custom attribute vehicle%n", response.getId());
+        System.out.printf("Created invoice %s with custom attribute%n", response.getId());
     }
 
     @Test(expected = TwikeyClient.UserException.class)


### PR DESCRIPTION
Allow passing one or more custom attributes directly in the invoice object via . Each entry is serialized as a top-level key-value pair in the JSON request body, matching the API behaviour for custom fields on invoice creation.