### PR TITLE
Improve custom attribute support in UpdateInvoiceRequest

### DIFF
--- a/src/main/java/com/twikey/modal/InvoiceRequests.java
+++ b/src/main/java/com/twikey/modal/InvoiceRequests.java
@@ -254,7 +254,7 @@ public interface InvoiceRequests {
      *   <li>ref (String): Invoice reference.</li>
      *   <li>pdf (String): Base64 encoded invoice document.</li>
      *   <li>status (String): Mark invoice as "booked", "archived" or "paid".</li>
-     *   <li>extra (String): Custom attributes in JSON or string form.</li>
+     *   <li>extra (Map): Custom attributes as key-value pairs, serialized as a JSON object under "extra".</li>
      * </ul>
      *
      * <p>Notes:</p>
@@ -272,7 +272,7 @@ public interface InvoiceRequests {
         private String ref;
         private String pdf;
         private String status;
-        private String extra;
+        private Map<String, String> extra;
 
         /**
          * @param id Unique invoice ID (required, from Twikey API)
@@ -293,7 +293,11 @@ public interface InvoiceRequests {
             putIfNotNull(result, "ref", ref);
             putIfNotNull(result, "pdf", pdf);
             putIfNotNull(result, "status", status);
-            putIfNotNull(result, "extra", extra);
+            if (extra != null) {
+                JSONObject extraJson = new JSONObject();
+                extra.forEach(extraJson::put);
+                result.put("extra", extraJson);
+            }
             return result;
         }
 
@@ -328,7 +332,7 @@ public interface InvoiceRequests {
             return this;
         }
 
-        public UpdateInvoiceRequest setExtra(String extra) {
+        public UpdateInvoiceRequest setExtra(Map<String, String> extra) {
             this.extra = extra;
             return this;
         }

--- a/src/test/java/com/twikey/InvoiceGatewayTest.java
+++ b/src/test/java/com/twikey/InvoiceGatewayTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
@@ -75,6 +76,21 @@ public class InvoiceGatewayTest {
         api.invoice().action(actionRequest);
     }
 
+
+    @Test
+    public void testUpdateInvoiceWithCustomAttribute() throws IOException, TwikeyClient.UserException {
+        Assume.assumeTrue("APIKey is set", apiKey != null);
+        String number = "Inv-UpdateAttr-" + System.currentTimeMillis();
+        InvoiceResponse.Invoice created = api.invoice().create(
+                new InvoiceRequests.CreateInvoiceRequest(number, 50.0, LocalDate.now().toString(), LocalDate.now().plusMonths(1).toString(), customer));
+        assertNotNull("Invoice Id", created.getId());
+
+        InvoiceRequests.UpdateInvoiceRequest update = new InvoiceRequests.UpdateInvoiceRequest(created.getId())
+                .setExtra(Map.of("myCustomAttribute", "myValue"));
+        InvoiceResponse.Invoice updated = api.invoice().update(update);
+        assertNotNull("Updated invoice Id", updated.getId());
+        System.out.printf("Updated invoice %s with custom attribute%n", updated.getId());
+    }
 
     @Test(expected = TwikeyClient.UserException.class)
     public void testUBLUpload() throws IOException, TwikeyClient.UserException {


### PR DESCRIPTION
Change the extra field from String to Map to properly serialize custom attributes as a JSON object under the extra key, matching the API contract.